### PR TITLE
 Fix depreciation warnings about importing React from React-Native package

### DIFF
--- a/examples/FloatingLabel/index.android.js
+++ b/examples/FloatingLabel/index.android.js
@@ -3,13 +3,8 @@
  * that demos the react-native-md-textinput
  */
 'use strict';
-import React, {
-  AppRegistry,
-  Component,
-  StyleSheet,
-  Text,
-  ScrollView
-} from 'react-native';
+import React, {Component} from "react";
+import {AppRegistry, StyleSheet, Text, ScrollView} from "react-native";
 
 import TextField from 'react-native-md-textinput';
 

--- a/examples/FloatingLabel/index.ios.js
+++ b/examples/FloatingLabel/index.ios.js
@@ -3,13 +3,8 @@
  * that demos the react-native-md-textinput
  */
 'use strict';
-import React, {
-  AppRegistry,
-  Component,
-  StyleSheet,
-  Text,
-  ScrollView
-} from 'react-native';
+import React, {Component} from "react";
+import {AppRegistry, StyleSheet, Text, ScrollView} from "react-native";
 
 import TextField from 'react-native-md-textinput';
 

--- a/lib/FloatingLabel.js
+++ b/lib/FloatingLabel.js
@@ -1,12 +1,6 @@
 'use strict';
-/* @flow */
-
-import React, {
-	Component,
-  StyleSheet,
-  Animated,
-	PropTypes
-} from 'react-native';
+import React, {Component, PropTypes} from "react";
+import {StyleSheet, Animated} from "react-native";
 
 export default class FloatingLabel extends Component {
   constructor(props: Object) {

--- a/lib/TextField.js
+++ b/lib/TextField.js
@@ -1,13 +1,6 @@
 'use strict';
-/* @flow */
-
-import React, {
-	Component,
-	View,
-	TextInput,
-	StyleSheet,
-	PropTypes
-} from 'react-native';
+import React, {Component, PropTypes} from "react";
+import {View, TextInput, StyleSheet} from "react-native";
 
 import Underline from './Underline';
 import FloatingLabel from './FloatingLabel';

--- a/lib/Underline.js
+++ b/lib/Underline.js
@@ -1,13 +1,6 @@
 'use strict';
-/* @flow */
-
-import React, {
-	Component,
-	View,
-  StyleSheet,
-  Animated,
-	PropTypes
-} from 'react-native';
+import React, {Component, PropTypes} from "react";
+import {View, StyleSheet, Animated} from "react-native";
 
 export default class Underline extends Component {
 	constructor(props: Object) {


### PR DESCRIPTION
Requiring React API from react-native is now deprecated from 0.25
facebook/react-native@0b534d1
facebook/react-native@2eafcd4
https://github.com/facebook/react-native/releases/tag/v0.25.1

Used https://github.com/sibeliusseraphini/codemod-RN24-to-RN25