### PR TITLE
Feature add multiline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ textFocusColor | string | | This string represents the hex code, rgb, or rgba co
 textBlurColor | string | | This string represents the hex code, rgb, or rgba color of the text entered in the TextInput when it is inactive.
 borderColor | string | `#E0E0E0` | This string represents the hex code, rgb, or rgba color of the TextInput underline when it is inactive.
 dense | bool | `false` | If true, it will render the "dense" input field which is smaller in height and has smaller font sizes. You can view more [here](https://www.google.com/design/spec/components/text-fields.html#text-fields-labels).
+multiline | bool | `false` | If true, it will allow multiline text input
+height | number | `undefined` | A number representing the initial height of the textInput
+autoGrow | bool | `false` | If true enables autogrow of the textInput 
 underlineColorAndroid | string | `rgba(0,0,0,0)` | This sets the default underline color on Android to transparent ([Issue #1](https://github.com/evblurbs/react-native-md-textinput/issues/1)).
 
 ### Style Overrides

--- a/lib/TextField.js
+++ b/lib/TextField.js
@@ -10,7 +10,8 @@ export default class TextField extends Component {
     super(props, context);
     this.state = {
       isFocused: false,
-      text: props.value
+      text: props.value,
+      height: props.height
     };
   }
   focus() {
@@ -32,6 +33,9 @@ export default class TextField extends Component {
         : this.refs.floatingLabel.sinkLabel();
       this.setState({text: nextProps.value});
     }
+    if(this.props.height !== nextProps.height){
+      this.setState({height: nextProps.height});
+    }
   }
   render() {
     let {
@@ -46,11 +50,15 @@ export default class TextField extends Component {
       onFocus,
       onBlur,
       onChangeText,
+      onChange,
       value,
       dense,
       inputStyle,
       wrapperStyle,
       labelStyle,
+      height,
+      autoGrow,
+      multiline,
       ...props
     } = this.props;
     return (
@@ -62,7 +70,8 @@ export default class TextField extends Component {
             color: textFocusColor
           } : {}, (!this.state.isFocused && textBlurColor) ? {
             color: textBlurColor
-          } : {}, inputStyle]}
+          } : {}, inputStyle,  this.state.height ? {height: this.state.height} : {}]}
+          multiline={multiline}
           onFocus={() => {
             this.setState({isFocused: true});
             this.refs.floatingLabel.floatLabel();
@@ -78,6 +87,12 @@ export default class TextField extends Component {
           onChangeText={(text) => {
             this.setState({text});
             onChangeText && onChangeText(text);
+          }}
+          onChange={(event) => {
+            if(autoGrow){
+              this.setState({height: event.nativeEvent.contentSize.height});
+            }
+            onChange && onChange(event);
           }}
           ref="input"
           value={this.state.text}
@@ -118,11 +133,15 @@ TextField.propTypes = {
   onFocus: PropTypes.func,
   onBlur: PropTypes.func,
   onChangeText: PropTypes.func,
+  onChange: PropTypes.func,
   value: PropTypes.string,
   dense: PropTypes.bool,
   inputStyle: PropTypes.object,
   wrapperStyle: PropTypes.object,
-  labelStyle: PropTypes.object
+  labelStyle: PropTypes.object,
+  multiline: PropTypes.bool,
+  autoGrow: PropTypes.bool,
+  height: PropTypes.oneOfType([PropTypes.oneOf(undefined), PropTypes.number])
 };
 
 TextField.defaultProps = {
@@ -132,7 +151,10 @@ TextField.defaultProps = {
   textColor: '#000',
   value: '',
   dense: false,
-  underlineColorAndroid: 'rgba(0,0,0,0)'
+  underlineColorAndroid: 'rgba(0,0,0,0)',
+  multiline: false,
+  autoGrow: false,
+  height: undefined
 };
 
 const styles = StyleSheet.create({

--- a/lib/TextField.js
+++ b/lib/TextField.js
@@ -62,7 +62,7 @@ export default class TextField extends Component {
       ...props
     } = this.props;
     return (
-      <View style={[dense ? styles.denseWrapper : styles.wrapper, wrapperStyle]} ref="wrapper">
+      <View style={[dense ? styles.denseWrapper : styles.wrapper, this.state.height ? {height: undefined}: {}, wrapperStyle]} ref="wrapper">
         <TextInput
           style={[dense ? styles.denseTextInput : styles.textInput, {
             color: textColor

--- a/lib/TextField.js
+++ b/lib/TextField.js
@@ -173,12 +173,14 @@ const styles = StyleSheet.create({
   textInput: {
     fontSize: 16,
     height: 34,
-    lineHeight: 34
+    lineHeight: 34,
+    textAlignVertical: 'top'
   },
   denseTextInput: {
     fontSize: 13,
     height: 27,
     lineHeight: 24,
-    paddingBottom: 3
+    paddingBottom: 3,
+    textAlignVertical: 'top'
   }
 });


### PR DESCRIPTION
This adds support for multiline text input with
`multiline={true}` and you can toggle the optional autogrow support with `autoGrow={true}`

(This is tested on both android + IOS, the previous one didn't work on IOS correctly..)