### PR TITLE
Fix underline not dynamicly resizing

### DIFF
--- a/lib/Underline.js
+++ b/lib/Underline.js
@@ -10,16 +10,8 @@ export default class Underline extends Component {
     };
     this.wrapperWidth = 0;
   }
-  componentDidMount() {
-    requestAnimationFrame(() => {
-      if (this.refs.wrapper == null) {
-        return;
-      }
-      const container = this.refs.wrapper;  // un-box animated view
-      container.measure((left, top, width, height) => {
-        this.wrapperWidth = width;
-      });
-    });
+  measure(e) {
+	  this.wrapperWidth = e.nativeEvent.layout.width
   }
   expandLine() {
     Animated.timing(this.state.lineLength, {
@@ -43,7 +35,7 @@ export default class Underline extends Component {
         style={[styles.underlineWrapper, {
           backgroundColor: borderColor
         }]}
-        ref="wrapper"
+        onLayout={this.measure.bind(this)}
       >
         <Animated.View
           style={[{


### PR DESCRIPTION
Updates the width to be calculated when RN calculates the element size, instead of only onComponentDidMount
