### PR TITLE
Feature/unmask password

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ multiline | bool | `false` | If true, it will allow multiline text input
 height | number | `undefined` | A number representing the initial height of the textInput
 autoGrow | bool | `false` | If true enables autogrow of the textInput 
 underlineColorAndroid | string | `rgba(0,0,0,0)` | This sets the default underline color on Android to transparent ([Issue #1](https://github.com/evblurbs/react-native-md-textinput/issues/1)).
+secureTextAllowUnmask | bool | `false` | This allows the secure password area to be unmasked.
+secureTextAllowUnmaskIconOn | element | `false` | This is the icon that is displayed when secureTextAllowUnmask is true
+secureTextAllowUnmaskIconOff | element | `false` | This is the icon that is displayed when secureTextAllowUnmask is true and the user has clicked the secureTextAllowUnmaskIconOn element
 
 ### Style Overrides
 

--- a/lib/TextField.js
+++ b/lib/TextField.js
@@ -1,6 +1,6 @@
 'use strict';
 import React, {Component, PropTypes} from "react";
-import {View, TextInput, Text, StyleSheet} from "react-native";
+import {View, TouchableWithoutFeedback, TextInput, Text, StyleSheet} from "react-native";
 
 import Underline from './Underline';
 import FloatingLabel from './FloatingLabel';
@@ -11,7 +11,8 @@ export default class TextField extends Component {
     this.state = {
       isFocused: false,
       text: props.value,
-      height: props.height
+      height: props.height,
+      isUnmasked: false
     };
   }
   focus() {
@@ -37,6 +38,9 @@ export default class TextField extends Component {
       this.setState({height: nextProps.height});
     }
   }
+  toggleSecureMask(){
+    this.setState({'isUnmasked': !this.state.isUnmasked})
+  }
   render() {
     let {
       label,
@@ -59,6 +63,10 @@ export default class TextField extends Component {
       height,
       autoGrow,
       multiline,
+      secureTextEntry,
+      secureTextAllowUnmask,
+      secureTextAllowUnmaskIconOn,
+      secureTextAllowUnmaskIconOff,
       ...props
     } = this.props;
 
@@ -106,9 +114,17 @@ export default class TextField extends Component {
           }}
           ref="input"
           value={this.state.text}
+          secureTextEntry={secureTextEntry && secureTextAllowUnmask ? !this.state.isUnmasked : props.secureTextEntry}
           {...props}
         />
       </View>
+        {
+          secureTextEntry && secureTextAllowUnmask ?
+              <TouchableWithoutFeedback onPress={this.toggleSecureMask.bind(this)}>
+                <View style={{opacity: !this.state.text.length ? 0.38 : 0.54}}>{!this.state.isUnmasked ? secureTextAllowUnmaskIconOn : secureTextAllowUnmaskIconOff}</View>
+              </TouchableWithoutFeedback >
+              : null
+        }
     </View>
         <Underline
           ref="underline"
@@ -154,7 +170,10 @@ TextField.propTypes = {
   multiline: PropTypes.bool,
   autoGrow: PropTypes.bool,
   height: PropTypes.oneOfType([PropTypes.oneOf(undefined), PropTypes.number]),
-  symbol: PropTypes.string
+  symbol: PropTypes.string,
+  secureTextAllowUnmask: PropTypes.bool,
+  secureTextAllowUnmaskIconOn: PropTypes.element,
+  secureTextAllowUnmaskIconOff: PropTypes.element
 };
 
 TextField.defaultProps = {
@@ -167,7 +186,8 @@ TextField.defaultProps = {
   underlineColorAndroid: 'rgba(0,0,0,0)',
   multiline: false,
   autoGrow: false,
-  height: undefined
+  height: undefined,
+  secureTextIsUnmasked: false
 };
 
 const styles = StyleSheet.create({

--- a/lib/TextField.js
+++ b/lib/TextField.js
@@ -61,16 +61,26 @@ export default class TextField extends Component {
       multiline,
       ...props
     } = this.props;
+
+    const textInputComposedStyles = [dense ? styles.denseTextInput : styles.textInput, {
+			color: textColor
+		}, (this.state.isFocused && textFocusColor) ? {
+			color: textFocusColor
+		} : {}, (!this.state.isFocused && textBlurColor) ? {
+			color: textBlurColor
+		} : {}, inputStyle,  this.state.height ? {height: this.state.height} : {}]
+
     return (
       <View style={[dense ? styles.denseWrapper : styles.wrapper, this.state.height ? {height: undefined}: {}, wrapperStyle]} ref="wrapper">
+        <View style={[styles.row, styles.flex]}>
+          {
+            this.props.symbol && this.props.value ?
+              <Text style={[textInputComposedStyles, styles.symbol]}>{this.props.symbol}</Text>
+            : null
+          }
+        <View style={styles.flex}>
         <TextInput
-          style={[dense ? styles.denseTextInput : styles.textInput, {
-            color: textColor
-          }, (this.state.isFocused && textFocusColor) ? {
-            color: textFocusColor
-          } : {}, (!this.state.isFocused && textBlurColor) ? {
-            color: textBlurColor
-          } : {}, inputStyle,  this.state.height ? {height: this.state.height} : {}]}
+          style={[textInputComposedStyles]}
           multiline={multiline}
           onFocus={() => {
             this.setState({isFocused: true});
@@ -98,6 +108,8 @@ export default class TextField extends Component {
           value={this.state.text}
           {...props}
         />
+      </View>
+    </View>
         <Underline
           ref="underline"
           highlightColor={highlightColor}
@@ -141,7 +153,8 @@ TextField.propTypes = {
   labelStyle: PropTypes.object,
   multiline: PropTypes.bool,
   autoGrow: PropTypes.bool,
-  height: PropTypes.oneOfType([PropTypes.oneOf(undefined), PropTypes.number])
+  height: PropTypes.oneOfType([PropTypes.oneOf(undefined), PropTypes.number]),
+  symbol: PropTypes.string
 };
 
 TextField.defaultProps = {
@@ -158,6 +171,12 @@ TextField.defaultProps = {
 };
 
 const styles = StyleSheet.create({
+  flex: {
+    flex: 1
+  },
+  row: {
+    flexDirection: 'row'
+  },
   wrapper: {
     height: 72,
     paddingTop: 30,
@@ -182,5 +201,12 @@ const styles = StyleSheet.create({
     lineHeight: 24,
     paddingBottom: 3,
     textAlignVertical: 'top'
+  },
+  symbol: {
+    textAlignVertical: 'auto',
+    lineHeight: undefined,
+    height: undefined,
+    position: 'relative',
+    bottom: -10
   }
 });

--- a/lib/TextField.js
+++ b/lib/TextField.js
@@ -1,6 +1,6 @@
 'use strict';
 import React, {Component, PropTypes} from "react";
-import {View, TextInput, StyleSheet} from "react-native";
+import {View, TextInput, Text, StyleSheet} from "react-native";
 
 import Underline from './Underline';
 import FloatingLabel from './FloatingLabel';


### PR DESCRIPTION
Hey,

I've added support to unmask the password field (opt in) https://material.google.com/components/text-fields.html#text-fields-password-input

![output](https://cloud.githubusercontent.com/assets/296106/18575769/65c4cfdc-7c1a-11e6-981e-fac28be7f5b1.gif)

it requires the user to supply the icon files that will be displayed (I didn't want to add a dependency to react native vector icons)

This is how its used

```
<TextInput
    label="Enter Password"
    secureTextEntry={true}
    value={this.state.text}
    onChangeText={(text) => this.setState({text: text})}
    secureTextAllowUnmask={true}
    secureTextAllowUnmaskIconOn={<Icon name="visibility"/>}
    secureTextAllowUnmaskIconOff={<Icon name="visibility-off"/>}
/>
```

this pull request is based from https://github.com/evblurbs/react-native-md-textinput/pull/23
