### PR TITLE
Change this.props.text to this.props.value

### DIFF
--- a/lib/TextField.js
+++ b/lib/TextField.js
@@ -27,7 +27,7 @@ export default class TextField extends Component {
     this.refs.wrapper.measureLayout(...args)
   }
   componentWillReceiveProps(nextProps: Object){
-    if(this.props.text !== nextProps.value){
+    if(this.props.value !== nextProps.value){
       nextProps.value.length !== 0 ?
         this.refs.floatingLabel.floatLabel()
         : this.refs.floatingLabel.sinkLabel();


### PR DESCRIPTION
RN TextInput uses 'value' property for setting default value, not 'text'. Setting an initial value with 'value' doesn't currently work, this fixes it.
