### PR TITLE
TextField.js - componentWillReceiveProps - Changing this.props.text t…

### DIFF
--- a/lib/TextField.js
+++ b/lib/TextField.js
@@ -27,7 +27,7 @@ export default class TextField extends Component {
     this.refs.wrapper.measureLayout(...args)
   }
   componentWillReceiveProps(nextProps: Object){
-    if(this.props.text !== nextProps.value){
+    if(this.state.text !== nextProps.value){
       nextProps.value.length !== 0 ?
         this.refs.floatingLabel.floatLabel()
         : this.refs.floatingLabel.sinkLabel();


### PR DESCRIPTION
…o this.state.text

The scenario is like so:
1. TextField is focused, but does not have a value.
2. props are changing
3. componentWillReceiveProps is triggered, and it's comparing `this.props.text` to `this.props.value`.
4. `this.props.text` is `undefined` and does not equal `this.props.value` which is an empty string
5. `sinkLabel` function is called, but TextField is still focused. (This is the issue)

In my opinion, `text` value should be read from the `state` and not the `props`.

Please let me know what you think :-)
