### PR TITLE
Fix onChangeText and value TextInput control

### DIFF
--- a/lib/TextField.js
+++ b/lib/TextField.js
@@ -85,7 +85,6 @@ export default class TextField extends Component {
             onBlur && onBlur();
           }}
           onChangeText={(text) => {
-            this.setState({text});
             onChangeText && onChangeText(text);
           }}
           onChange={(event) => {
@@ -95,7 +94,7 @@ export default class TextField extends Component {
             onChange && onChange(event);
           }}
           ref="input"
-          value={this.state.text}
+          value={value}
           {...props}
         />
         <Underline


### PR DESCRIPTION
These controls should be left to the user using the component and not set with internal state. Using your own internal state does not allow the user to validate any input going into the component, ie cannot control maximum character length, types of characters allowed, etc.