### PR TITLE
Bug Fix: Undefined error When 'value' prop is null

### DIFF
--- a/lib/TextField.js
+++ b/lib/TextField.js
@@ -10,7 +10,7 @@ export default class TextField extends Component {
     super(props, context);
     this.state = {
       isFocused: false,
-      text: props.value,
+      text: props.value || '',
       height: props.height
     };
   }
@@ -28,7 +28,7 @@ export default class TextField extends Component {
   }
   componentWillReceiveProps(nextProps: Object){
     if(this.props.text !== nextProps.value){
-      nextProps.value.length !== 0 ?
+      (nextProps.value && nextProps.value.length !== 0) ?
         this.refs.floatingLabel.floatLabel()
         : this.refs.floatingLabel.sinkLabel();
       this.setState({text: nextProps.value});


### PR DESCRIPTION
Bug Fix: if you pass a null value to the ‘value’ prop it returns an undefined error so I added a undefined check to the value prop so if value is a null then it sets state as a blank string