### PR TITLE
Added support for React 16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ npm-debug.log
 # examples
 examples/FloatingLabel/node_modules/
 examples/FloatingLabel/lib/
+
+# JetBrains IDEs
+.idea

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ React Native TextInput styled with Material Design.
 npm install react-native-md-textinput
 ```
 
+#### Supporting older versions of react-native 
+| RN version | Library Version |
+|------------|-----------------|
+| \>= 0.46   | \>= 2.1.0       |
+| < 0.46     | 2.0.4           |
+
 ## Usage
 
 I'm going to refer to the `react-native-md-textinput` Component as `TextField`. You can name it whatever you like when importing it.

--- a/lib/FloatingLabel.js
+++ b/lib/FloatingLabel.js
@@ -1,5 +1,6 @@
 'use strict';
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import PropTypes from "prop-types";
 import {StyleSheet, Animated} from "react-native";
 
 export default class FloatingLabel extends Component {

--- a/lib/TextField.js
+++ b/lib/TextField.js
@@ -1,5 +1,6 @@
 'use strict';
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import PropTypes from "prop-types";
 import {View, TextInput, StyleSheet} from "react-native";
 
 import Underline from './Underline';

--- a/lib/Underline.js
+++ b/lib/Underline.js
@@ -1,5 +1,6 @@
 'use strict';
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import PropTypes from "prop-types";
 import {View, StyleSheet, Animated} from "react-native";
 
 export default class Underline extends Component {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-md-textinput",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "React Native TextInput styled with Material Design.",
   "main": "lib/TextField.js",
   "repository": {
@@ -19,5 +19,8 @@
   },
   "author": "Evan Johnson",
   "license": "MIT",
-  "homepage": "https://github.com/evblurbs/react-native-md-textinput#readme"
+  "homepage": "https://github.com/evblurbs/react-native-md-textinput#readme",
+  "peerDependencies": {
+    "react-native": ">=0.46.0"
+  }
 }


### PR DESCRIPTION
React Native >= v.46 requires use of React v.16 which drops `React.PropTypes` in favor of `prop-types` package. Have to adjust.