### PR TITLE
To support react native 0.52+ version.

### DIFF
--- a/lib/FloatingLabel.js
+++ b/lib/FloatingLabel.js
@@ -1,5 +1,6 @@
 'use strict';
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import PropTypes from 'prop-types';
 import {StyleSheet, Animated} from "react-native";
 
 export default class FloatingLabel extends Component {


### PR DESCRIPTION
This will help the developers to use this application for 0.52+ versions.
Prop types are moved out of react.
we can use import PropTypes from 'prop-types';