### PR TITLE
[Bug fix] Removed react proptypes and added prop-types support

### DIFF
--- a/lib/FloatingLabel.js
+++ b/lib/FloatingLabel.js
@@ -1,5 +1,6 @@
 'use strict';
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import PropTypes from "prop-types";
 import {StyleSheet, Animated} from "react-native";
 
 export default class FloatingLabel extends Component {

--- a/lib/TextField.js
+++ b/lib/TextField.js
@@ -1,5 +1,6 @@
 'use strict';
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import PropTypes from "prop-types";
 import {View, TextInput, StyleSheet} from "react-native";
 
 import Underline from './Underline';

--- a/lib/Underline.js
+++ b/lib/Underline.js
@@ -1,5 +1,6 @@
 'use strict';
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import PropTypes from "prop-types";
 import {View, StyleSheet, Animated} from "react-native";
 
 export default class Underline extends Component {


### PR DESCRIPTION
Fixed  -  Does not works with React 16.x.x because PropTypes has been removed from React 16 above.